### PR TITLE
Add Jest tests and configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ Paper Plane Sim is a lightweight, browser-based paper airplane flight simulator.
 
 You can also simply open `paper-plane.html` directly in a browser, though some features may require a server for best results.
 
+## Testing
+Install dependencies and run the test suite with:
+
+```bash
+npm install
+npm test
+```
+
 ## Controls
 - Keyboard: `W/S` pitch, `A/D` roll, `Q/E` yaw, `Space` throw, `P` pause.
 - Gamepad: left stick for pitch/roll, right stick X for yaw, `A` throw, `Start` pause.

--- a/package.json
+++ b/package.json
@@ -5,9 +5,16 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "start": "vite"
+    "start": "vite",
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
   },
   "devDependencies": {
-    "vite": "^5.0.0"
+    "vite": "^5.0.0",
+    "jest": "^29.7.0"
+  },
+  "jest": {
+    "testEnvironment": "node",
+    "transform": {},
+    "extensionsToTreatAsEsm": [".js"]
   }
 }

--- a/tests/quat.test.js
+++ b/tests/quat.test.js
@@ -1,0 +1,13 @@
+import { Quat } from '../src/quat.js';
+import { Vec3 } from '../src/vec3.js';
+
+test('quaternion rotates vector around Z axis', () => {
+  const axis = new Vec3(0, 0, 1);
+  const q = Quat.fromAxisAngle(axis, Math.PI / 2);
+  const v = new Vec3(1, 0, 0);
+  const rotated = q.rotate(v);
+  expect(rotated.x).toBeCloseTo(0);
+  expect(rotated.y).toBeCloseTo(1);
+  expect(rotated.z).toBeCloseTo(0);
+});
+

--- a/tests/rng.test.js
+++ b/tests/rng.test.js
@@ -1,0 +1,18 @@
+import { RNG } from '../src/utils.js';
+
+test('deterministic sequence', () => {
+  const rng1 = new RNG('seed');
+  const rng2 = new RNG('seed');
+  expect(rng1.next()).toBeCloseTo(rng2.next());
+  expect(rng1.next()).toBeCloseTo(rng2.next());
+});
+
+test('range within bounds', () => {
+  const rng = new RNG('bounds');
+  for (let i = 0; i < 5; i++) {
+    const v = rng.range(5, 10);
+    expect(v).toBeGreaterThanOrEqual(5);
+    expect(v).toBeLessThanOrEqual(10);
+  }
+});
+

--- a/tests/vec3.test.js
+++ b/tests/vec3.test.js
@@ -1,0 +1,23 @@
+import { Vec3 } from '../src/vec3.js';
+
+test('vector addition', () => {
+  const result = new Vec3(1, 2, 3).add(new Vec3(4, 5, 6));
+  expect(result).toEqual({ x: 5, y: 7, z: 9 });
+});
+
+test('cross product', () => {
+  const a = new Vec3(1, 0, 0);
+  const b = new Vec3(0, 1, 0);
+  const c = a.cross(b);
+  expect(c.x).toBeCloseTo(0);
+  expect(c.y).toBeCloseTo(0);
+  expect(c.z).toBeCloseTo(1);
+});
+
+test('normalization', () => {
+  const v = new Vec3(3, 4, 0).norm();
+  expect(v.x).toBeCloseTo(0.6);
+  expect(v.y).toBeCloseTo(0.8);
+  expect(v.z).toBeCloseTo(0);
+});
+

--- a/tests/wind.test.js
+++ b/tests/wind.test.js
@@ -1,0 +1,18 @@
+import { Vec3 } from '../src/vec3.js';
+import { makeWind, buildUpdrafts } from '../src/wind.js';
+import { RNG } from '../src/utils.js';
+
+test('wind field deterministic output', () => {
+  const wind = makeWind('house', 12345);
+  const v = wind(new Vec3(0, 0, 0), 0);
+  expect(v.x).toBeCloseTo(-0.1906510079);
+  expect(v.y).toBeCloseTo(-0.0023318667);
+  expect(v.z).toBeCloseTo(0.2276571916);
+});
+
+test('buildUpdrafts creates expected count', () => {
+  const bounds = { min: new Vec3(-5, 0, -5), max: new Vec3(5, 10, 5) };
+  const list = buildUpdrafts('house', new RNG('seed'), bounds);
+  expect(list).toHaveLength(6);
+});
+


### PR DESCRIPTION
## Summary
- configure Jest and add test script
- document how to run `npm test`
- add unit tests for Vec3, Quat, RNG, and wind utilities

## Testing
- `npm test` *(fails: Cannot find module 'jest')*


------
https://chatgpt.com/codex/tasks/task_e_689ea26af530832c802f01dc0051615f