### PR TITLE
Preload audio assets and expose buffers

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,8 +138,14 @@
       <p>Pause or resume the game anytime.</p>
       <button class="tut-next">Start</button>
     </div>
-  </div>
 </div>
+</div>
+
+<!-- Preloaded audio assets -->
+<audio id="track-kansai" preload="auto" src="https://example.com/kansai90s.mp3" hidden></audio>
+<audio id="track-sidewinder" preload="auto" src="https://example.com/sidewinder.mp3" hidden></audio>
+<audio id="track-sunshowers" preload="auto" src="https://example.com/sunshowers.mp3" hidden></audio>
+<audio id="effect-swoosh" preload="auto" src="https://example.com/swoosh.mp3" hidden></audio>
 
 <script type="module" src="/src/main.js"></script>
 </body>

--- a/src/audio/background.js
+++ b/src/audio/background.js
@@ -1,8 +1,6 @@
-const PLAYLIST=[
-  {title:'Kansai 90s',artist:'Shuriken Miasma',url:'https://example.com/kansai90s.mp3'},
-  {title:'Sidewinder',artist:'Shuriken Miasma',url:'https://example.com/sidewinder.mp3'},
-  {title:'Sunshowers',artist:'Shuriken Miasma',url:'https://example.com/sunshowers.mp3'}
-];
+import { tracks } from './loader.js';
+
+const PLAYLIST = tracks;
 
 let current=null;
 let infoEl=null;
@@ -14,9 +12,10 @@ function setTrackInfo(text){
 
 function playRandomTrack(){
   stopTrack();
-  const track=PLAYLIST[Math.floor(Math.random()*PLAYLIST.length)];
-  current=new Audio(track.url);
-  current.loop=false;
+  const track = PLAYLIST[Math.floor(Math.random()*PLAYLIST.length)];
+  current = track.el;
+  current.currentTime = 0;
+  current.loop = false;
   current.play();
   setTrackInfo(`${track.title} — ${track.artist}`);
 }

--- a/src/audio/loader.js
+++ b/src/audio/loader.js
@@ -1,0 +1,38 @@
+// Preload audio elements defined in index.html and expose when ready
+
+const trackList = [
+  { id: 'track-kansai', title: 'Kansai 90s', artist: 'Shuriken Miasma' },
+  { id: 'track-sidewinder', title: 'Sidewinder', artist: 'Shuriken Miasma' },
+  { id: 'track-sunshowers', title: 'Sunshowers', artist: 'Shuriken Miasma' }
+];
+
+const effectMap = {
+  swoosh: 'effect-swoosh'
+};
+
+function getElement(id) {
+  return /** @type {HTMLAudioElement} */ (document.getElementById(id));
+}
+
+function waitFor(el) {
+  return new Promise(resolve => {
+    if (el.readyState >= 4) {
+      resolve();
+    } else {
+      el.addEventListener('canplaythrough', () => resolve(), { once: true });
+    }
+  });
+}
+
+const tracks = trackList.map(info => ({ ...info, el: getElement(info.id) }));
+const effects = Object.fromEntries(
+  Object.entries(effectMap).map(([name, id]) => [name, getElement(id)])
+);
+
+const audioReady = Promise.all([
+  ...tracks.map(t => waitFor(t.el)),
+  ...Object.values(effects).map(waitFor)
+]);
+
+export { tracks, effects, audioReady };
+

--- a/src/main.js
+++ b/src/main.js
@@ -5,6 +5,7 @@ import { makeWind, buildUpdrafts } from './wind.js';
 import { Plane, BASE_PLANES, BASE_MATERIALS } from './plane.js';
 import { Quat } from './quat.js';
 import { playRandomTrack, stopTrack, setTrackInfo } from './audio/background.js';
+import { audioReady, effects } from './audio/loader.js';
 
 /**************** Camera & draw ****************/
 let canvas=document.getElementById('canvas'),ctx=canvas.getContext('2d');
@@ -177,7 +178,7 @@ function checkBadges(){
 }
 function makeParams(){const shape=BASE_PLANES[ui.plane.value]||BASE_PLANES.dart;const mat=BASE_MATERIALS[ui.material.value]||BASE_MATERIALS.printer;return{...shape,mass:shape.mass*mat.mass,wingArea:shape.wingArea*mat.wingArea,CD0:shape.CD0*mat.CD0,color:mat.color,texture:mat.texture}}
 function updateMaterialIcon(){const m=BASE_MATERIALS[ui.material.value];if(m)ui.materialIcon.style.backgroundImage=`url(${m.texture})`}
-function rebuild(){stopTrack();rng=new RNG(ui.seed.value||'seed');const L=ui.level.value;let s; if(L==='house')s=buildHouse(rng); if(L==='office')s=buildOffice(rng); if(L==='mall')s=buildMall(rng); if(L==='stadium')s=buildStadium(rng); if(L==='google')s=buildGoogleCity(rng); scene=s;windField=makeWind(L,rng.seed);updrafts=buildUpdrafts(L,rng,scene.bounds);plane=new Plane(makeParams());plane.reset(scene.spawn.clone(),new Vec3(0,0,1),+ui.throw.value);ui.levelDetail.textContent=`edges:${scene.edges.length} boxes:${scene.boxes.length} updrafts:${updrafts.length}`;sessionTime=0;updateMaterialIcon();setTimeout(()=>playRandomTrack(),300)}
+function rebuild(){stopTrack();rng=new RNG(ui.seed.value||'seed');const L=ui.level.value;let s; if(L==='house')s=buildHouse(rng); if(L==='office')s=buildOffice(rng); if(L==='mall')s=buildMall(rng); if(L==='stadium')s=buildStadium(rng); if(L==='google')s=buildGoogleCity(rng); scene=s;windField=makeWind(L,rng.seed);updrafts=buildUpdrafts(L,rng,scene.bounds);plane=new Plane(makeParams());plane.reset(scene.spawn.clone(),new Vec3(0,0,1),+ui.throw.value);ui.levelDetail.textContent=`edges:${scene.edges.length} boxes:${scene.boxes.length} updrafts:${updrafts.length}`;sessionTime=0;updateMaterialIcon();audioReady.then(()=>setTimeout(()=>playRandomTrack(),300))}
 main
 refreshPlaneList();
 refreshMaterialList();
@@ -282,6 +283,7 @@ function throwPlane(){
   targetsHitStep=0;
   flightLog=[];wasThrown=false;
   replaying=false;ghostPlane=null;
+  audioReady.then(()=>{const s=effects.swoosh; if(s){s.currentTime=0; s.play();}});
   focusCanvas();
 }
 function collide(){ if(ui.ghost.checked) return false; if(plane.pos.y<scene.bounds.min.y-0.2) return true; for(const b of scene.boxes){ if(pointInBox(plane.pos,b)) return true } return false }


### PR DESCRIPTION
## Summary
- Add hidden audio elements to index.html for background tracks and a swoosh effect
- Implement audio loader module exposing preloaded tracks and effects
- Update background playback and main script to use preloaded audio and play a throw swoosh

## Testing
- `npm test` *(fails: Option: extensionsToTreatAsEsm includes '.js' which is always inferred)*

------
https://chatgpt.com/codex/tasks/task_e_689ec7ee39d0832cbc14ef70ce1de38d