### PR TITLE
Add audio volume controls with persistence

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,6 +67,21 @@
     </select>
   </div>
   <div class="row">
+    <label>Master Vol</label>
+    <input id="masterVol" type="range" min="0" max="1" step="0.01" aria-label="Master volume" />
+    <button id="masterMute" aria-label="Mute or unmute master">Mute</button>
+  </div>
+  <div class="row">
+    <label>Music Vol</label>
+    <input id="musicVol" type="range" min="0" max="1" step="0.01" aria-label="Music volume" />
+    <button id="musicMute" aria-label="Mute or unmute music">Mute</button>
+  </div>
+  <div class="row">
+    <label>SFX Vol</label>
+    <input id="sfxVol" type="range" min="0" max="1" step="0.01" aria-label="Sound effects volume" />
+    <button id="sfxMute" aria-label="Mute or unmute sound effects">Mute</button>
+  </div>
+  <div class="row">
     <label>Assist</label>
     <input id="assist" type="checkbox" checked aria-label="Auto-stabilize" />
     <label for="assist">Auto-stabilize</label>


### PR DESCRIPTION
## Summary
- add master, music, and sfx volume sliders with mute buttons in HUD
- manage audio context gain and mute/resume state in `main.js`
- persist audio preferences in `localStorage` so settings survive reloads

## Testing
- `npm test` *(fails: Option extensionsToTreatAsEsm includes '.js')*

------
https://chatgpt.com/codex/tasks/task_e_689eca451c84832ca3de383b7effb479