### PR TITLE
Add synthesized wind and collision audio

### DIFF
--- a/src/audio/controller.js
+++ b/src/audio/controller.js
@@ -1,4 +1,5 @@
 import { audioReady, effects } from './loader.js';
+import { playCollisionBurst } from './synth.js';
 
 const collisionEffects = {
   dart: 'collision-dart',
@@ -32,6 +33,7 @@ function playCollision(planeKey) {
   if (name) {
     playEffect(name);
   }
+  playCollisionBurst(planeKey);
 }
 
 function playUpdraft() {

--- a/src/audio/synth.js
+++ b/src/audio/synth.js
@@ -1,0 +1,59 @@
+let audioCtx = null;
+let dest = null;
+
+function initSynth(ctx, d) {
+  audioCtx = ctx;
+  dest = d;
+}
+
+function createWind() {
+  if (!audioCtx) return { update() {} };
+  const bufSize = 2 * audioCtx.sampleRate;
+  const buffer = audioCtx.createBuffer(1, bufSize, audioCtx.sampleRate);
+  const data = buffer.getChannelData(0);
+  for (let i = 0; i < bufSize; i++) data[i] = Math.random() * 2 - 1;
+  const src = audioCtx.createBufferSource();
+  src.buffer = buffer;
+  src.loop = true;
+  const filter = audioCtx.createBiquadFilter();
+  filter.type = 'lowpass';
+  filter.frequency.value = 1000;
+  const gain = audioCtx.createGain();
+  gain.gain.value = 0;
+  src.connect(filter);
+  filter.connect(gain);
+  gain.connect(dest || audioCtx.destination);
+  src.start();
+  return {
+    update(s) {
+      const v = Math.min(0.1, s * 0.02);
+      gain.gain.setTargetAtTime(v, audioCtx.currentTime, 0.05);
+    }
+  };
+}
+
+const collisionFreq = {
+  dart: 600,
+  glider: 300,
+  stunt: 800,
+  heavy: 200,
+  snub: 500,
+  fighter: 900
+};
+
+function playCollisionBurst(type) {
+  if (!audioCtx) return;
+  const f = collisionFreq[type] || 400;
+  const osc = audioCtx.createOscillator();
+  osc.type = 'sawtooth';
+  osc.frequency.value = f;
+  const gain = audioCtx.createGain();
+  gain.gain.setValueAtTime(0.3, audioCtx.currentTime);
+  gain.gain.exponentialRampToValueAtTime(0.001, audioCtx.currentTime + 0.2);
+  osc.connect(gain);
+  gain.connect(dest || audioCtx.destination);
+  osc.start();
+  osc.stop(audioCtx.currentTime + 0.21);
+}
+
+export { initSynth, createWind, playCollisionBurst };

--- a/src/main.js
+++ b/src/main.js
@@ -7,6 +7,7 @@ import { Quat } from './quat.js';
 import { playRandomTrack, stopTrack, setTrackInfo } from './audio/background.js';
 import { tracks, effects, audioReady } from './audio/loader.js';
 import { playThrow, playCollision, playUpdraft } from './audio/controller.js';
+import { initSynth, createWind } from './audio/synth.js';
 
 /**************** Camera & draw ****************/
 let canvas=document.getElementById('canvas'),ctx=canvas.getContext('2d');
@@ -112,6 +113,8 @@ function saveAudio(){
   localStorage.setItem(AUDIO_SETTINGS_KEY,JSON.stringify({master:masterVol,music:musicVol,sfx:sfxVol,masterMute:masterMuted,musicMute:musicMuted,sfxMute:sfxMuted}));
 }
 applyVolumes();
+initSynth(audioCtx,sfxGain);
+const windAudio=createWind();
 ui.masterVol.addEventListener('input',()=>{masterVol=+ui.masterVol.value;if(!masterMuted)masterGain.gain.value=masterVol;saveAudio();});
 ui.musicVol.addEventListener('input',()=>{musicVol=+ui.musicVol.value;if(!musicMuted)musicGain.gain.value=musicVol;saveAudio();});
 ui.sfxVol.addEventListener('input',()=>{sfxVol=+ui.sfxVol.value;if(!sfxMuted)sfxGain.gain.value=sfxVol;saveAudio();});
@@ -490,6 +493,7 @@ let last=performance.now(),acc=0;rebuild();setTimeout(()=>throwPlane(),400);
   ui.alt.textContent=(plane.pos.y).toFixed(1);
   ui.wnd.textContent=(plane._wind||0).toFixed(1);
   ui.windDir.textContent=((wDir*180/Math.PI+360)%360).toFixed(0);
+  windAudio.update(plane._wind||0);
   fpsCounter.tick(now);
   requestAnimationFrame(frame);
  }


### PR DESCRIPTION
## Summary
- Add audio synthesizer with wind noise and plane-specific collision bursts
- Integrate wind sound into main loop with speed-based volume
- Trigger synthesizer collision burst from audio controller

## Testing
- `npm test` *(fails: Option: extensionsToTreatAsEsm: ['.js'] includes '.js' which is always inferred based on type in its nearest package.json.)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689ecb9d1468832cb962e849a318078c